### PR TITLE
Use session for the qemu uri

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,3 @@
 provider "libvirt" {
-  uri = "qemu:///system"
+  uri = "qemu:///session"
 }


### PR DESCRIPTION
This option seems to make both Linux and MacOSX happy. If this causes issues down the line:
1. Remove `provider.tf`
2. Modify the Readme where needed
3. Modify all examples to include custom provider configuration